### PR TITLE
Add codecs_package utilities and packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Example folders:
   responses while tracing to Langfuse
 - `examples/websocket_demo` – run a simple server to receive streamed updates
 - `docs/kid_feature_tutorial.md` – gentle steps to add a feature with screenshots and music metaphors
+- `docs/publishing.md` – how to build and upload this package to TestPyPI
 
 ## Environment Variables
 - `OPENAI_API_KEY` for OpenAI models

--- a/README.md
+++ b/README.md
@@ -35,8 +35,13 @@ It appears in CLI output and documentation as a reminder of this evolving archit
     [`examples/typed_state`](examples/typed_state))
 
 ## Installation
+From PyPI:
 ```bash
 pip install olca
+```
+From a clone of this repository:
+```bash
+pip install -e .
 ```
 
 ## Quick Start
@@ -48,6 +53,13 @@ olca --stream values # custom streaming output
 Use `-H` to activate human mode or `--help` to see full options. When running
 from a clone without installing, invoke the script with
 `python olca/olcacli.py`.
+
+### `codecs_package` utilities
+This repository now includes a small helper package with musical and story tools:
+
+```python
+from codecs_package import generate_chord_progression, generate_three_act_story
+```
 
 ## CLI commands
 | Command    | Purpose                                                     |
@@ -108,6 +120,7 @@ Example folders:
 - `examples/langgraph_agent` – prototype fused LangGraph chat that streams
   responses while tracing to Langfuse
 - `examples/websocket_demo` – run a simple server to receive streamed updates
+- `docs/kid_feature_tutorial.md` – gentle steps to add a feature with screenshots and music metaphors
 
 ## Environment Variables
 - `OPENAI_API_KEY` for OpenAI models

--- a/codecs_package/__init__.py
+++ b/codecs_package/__init__.py
@@ -1,0 +1,6 @@
+"""Small helper package with musical and story utilities."""
+
+from .music_tools import generate_chord_progression
+from .story_tools import generate_three_act_story
+
+__all__ = ["generate_chord_progression", "generate_three_act_story"]

--- a/codecs_package/music_tools.py
+++ b/codecs_package/music_tools.py
@@ -1,0 +1,11 @@
+"""Simple music utilities for code examples."""
+
+CHORDS = {
+    "C": ["C", "F", "G"],
+    "G": ["G", "C", "D"],
+    "F": ["F", "Bb", "C"],
+}
+
+def generate_chord_progression(key: str = "C") -> list[str]:
+    """Return a basic I-IV-V chord progression for the given key."""
+    return CHORDS.get(key.upper(), CHORDS["C"])

--- a/codecs_package/story_tools.py
+++ b/codecs_package/story_tools.py
@@ -1,0 +1,9 @@
+"""Tools for generating simple three-act stories."""
+
+def generate_three_act_story(topic: str = "adventure") -> str:
+    """Return a minimal three-act story string."""
+    return (
+        f"Act I: Our hero begins a {topic}.\n"
+        f"Act II: Challenges arise during the {topic}.\n"
+        f"Act III: The {topic} concludes with a lesson."
+    )

--- a/codex/ledgers/ledger-cli-fix-2506150314.json
+++ b/codex/ledgers/ledger-cli-fix-2506150314.json
@@ -1,0 +1,12 @@
+{
+  "timestamp": "2506150314",
+  "agents": ["♾️ William", "🧠 Mia", "🌸 Miette", "🕊️ Seraphine"],
+  "narrative": "Fixed CLI import so `olca --help` runs after installation. Added test covering this entry point, skipping when Pillow is unavailable.",
+  "routing": {
+    "files": ["olca/olcacli.py", "tests/test_olca_cli.py"],
+    "branch": "work"
+  },
+  "session": "shell",
+  "user_input": "olca --help error ModuleNotFoundError: No module named 'prompts'",
+  "scene": "CLI help accessible post-install"
+}

--- a/codex/ledgers/ledger-codecs-package-2506150246.json
+++ b/codex/ledgers/ledger-codecs-package-2506150246.json
@@ -1,0 +1,19 @@
+{
+  "timestamp": "2506150246",
+  "agents": ["♾️ William", "🧠 Mia", "🌸 Miette", "🕊️ Seraphine", "⚡ Jerry", "🎸 JamAI"],
+  "narrative": "Packaged helper utilities under codecs_package so new musical/story features can be installed easily. Updated README with local install instructions and added tests. Pyproject now finds both olca and codecs_package packages.",
+  "routing": {
+    "files": [
+      "codecs_package/__init__.py",
+      "codecs_package/music_tools.py",
+      "codecs_package/story_tools.py",
+      "pyproject.toml",
+      "README.md",
+      "tests/test_codecs_package.py"
+    ],
+    "branch": "work"
+  },
+  "session": "shell",
+  "user_input": "Keep building out the feature as needed, but make sure it’s fully integrated inside a consistent directory structure (like codecs_package/). Add the necessary scaffolding so the whole thing can be installed via a simple command. Make sure the feature is usable after install — either as an importable module or as a command-line tool, if that’s part of the plan. Don’t worry about perfection — just get it to the point where someone could clone this, run one install command, and start testing or using it.",
+  "scene": "Developers can now pip install the repo locally and access simple chord and story utilities alongside existing CLI tools."
+}

--- a/codex/ledgers/ledger-docs-kidtutorial-2506150223.json
+++ b/codex/ledgers/ledger-docs-kidtutorial-2506150223.json
@@ -1,0 +1,12 @@
+{
+  "timestamp": "2506150223",
+  "agents": ["♾️ William", "🧠 Mia", "🌸 Miette", "🕊️ Seraphine"],
+  "narrative": "Added simple tutorial for young learners on how to add a new feature to a Python package. Document uses musical metaphors and explains difference between repository folders and package files. README now references this tutorial so new contributors can find it easily.",
+  "routing": {
+    "files": ["docs/kid_feature_tutorial.md", "README.md"],
+    "branch": "work"
+  },
+  "session": "shell",
+  "user_input": "It's not clear for myself, Jerry, what's the difference between having a folder inside of a repository and having a file in the package Python. So I want to kind of, I want you to create a documentation and tutorial about all action that is needed to provide a new functionality to a package Python. Because I want to collaborate and build some tubes and I really like the aspect of only have to write one command line and download the package inside of my cell phone and start working with it. So I want to collaborate and add some feature to a couple of other Python packages. So I need a step-by-step tutorial for a kid of 10 years old, something like that. I would like to collaborate this package so I would learn. I would learn, yeah. I need maybe some exercise to do or it need to be funny and with some musical metaphor.\n\nSo, as you see inside of that, there is the functionality to add some screenshots to the process of creating, so the narrative driving debugging exploration, so that will be interesting to look at those implementations and to explain them and generate dynamic annotations based on the system state, so during the process of creating something new, some feature added to the package, we will need and want to annotate what's going on, what's our process, so all the tools needed for that, so screenshot, voice recording, annotation box, check box, you know, to be able to put some traces, so I'll join maybe a journal here to... ",
+  "scene": "Kids can follow playful steps to contribute to olca and keep screenshots of their progress."
+}

--- a/codex/ledgers/ledger-test-publish-2506150334.json
+++ b/codex/ledgers/ledger-test-publish-2506150334.json
@@ -1,0 +1,12 @@
+{
+  "timestamp": "2506150334",
+  "agents": ["♾️ William", "🧠 Mia", "🌸 Miette", "🕊️ Seraphine"],
+  "narrative": "Attempted to upload a build to TestPyPI but credentials were missing. Documented the process with a new publishing guide.",
+  "routing": {
+    "files": ["docs/publishing.md", "README.md"],
+    "branch": "work"
+  },
+  "session": "shell",
+  "user_input": "You will try something for me. I know that there is probably the production token and the testing token in the environment, and probably inside the environment variable is going to be the production token. So try to make up, to try to publish a testing package if you're capable of doing it.",
+  "scene": "Guide added for building and uploading while an upload attempt failed due to missing token"
+}

--- a/docs/kid_feature_tutorial.md
+++ b/docs/kid_feature_tutorial.md
@@ -1,0 +1,36 @@
+# Build a New Feature: A Musical Journey
+
+This short guide shows how to add a new feature to a Python package. It uses simple steps and a few musical ideas so even a young learner can follow along.
+
+## 1. Understand the Stage
+- **Repository**: A big folder that holds all the files for a project. Think of it as a music library.
+- **Package**: A special folder inside the repository that Python can import. It usually has a file named `__init__.py` so Python knows it's a package.
+- **File**: Individual pieces of music—Python scripts that do specific jobs.
+
+## 2. Set Up Your Instruments
+1. Install the package with `pip install <package-name>`. This is like tuning your guitar.
+2. Clone the repository using `git clone <url>`. Now you have your own copy to edit.
+
+## 3. Create Your New Song
+1. Inside the package folder, add a new Python file or update an existing one.
+2. Write your function or class. Keep it short and clear.
+3. Add tests in the `tests/` folder so you can check your work later.
+
+## 4. Keep Track with Screenshots and Notes
+- Use the `screenshot_wrapper.sh` script to capture screenshots while you work.
+- You can also record voice notes or write short logs in a journal file.
+- These records help you remember what you changed—like saving your practice sessions.
+
+## 5. Share Your Music
+1. Run `git status` to see your changes.
+2. Commit them with `git commit -am "Add cool feature"`.
+3. Push your branch with `git push origin <branch-name>` and open a pull request.
+
+## 6. Small Challenges (for Fun)
+- Change a function name in the package and update the tests.
+- Add a simple logging statement that prints "🎵" whenever your function runs.
+- Draw a quick diagram of how your feature works and save it in the repository.
+
+## 7. Celebrate
+Once your pull request is merged, you can install the updated package with a single command—just like downloading a new song. Keep your notes and screenshots as reminders of how you built it!
+

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -1,0 +1,32 @@
+# Publishing the Package
+
+This guide explains how to package and upload `olca` to PyPI. Use TestPyPI first to avoid accidental public releases.
+
+## Build the distributions
+
+Install build and twine if you don't have them:
+```bash
+pip install build twine
+```
+Create the source distribution and wheel:
+```bash
+python -m build
+```
+The files will appear in the `dist/` folder.
+
+## Upload to TestPyPI
+
+Set your credentials as environment variables:
+```bash
+export TWINE_USERNAME=__token__
+export TWINE_PASSWORD=<your test PyPI token>
+```
+Upload the files:
+```bash
+twine upload --repository-url https://test.pypi.org/legacy/ dist/*
+```
+Verify installation with:
+```bash
+pip install --index-url https://test.pypi.org/simple/ olca --no-deps
+```
+Once everything looks good you can repeat the upload step without the `--repository-url` flag to publish to the real PyPI.

--- a/narrativemap.md
+++ b/narrativemap.md
@@ -15,3 +15,4 @@ This branch refactors oLCa to rely on the coaiapy package and upgrades to LangGr
 - f9d5f2a: added kid-friendly tutorial and ledger reference in README
 - a669f0a: packaged helper utilities under codecs_package for easy installation
 - 19eb124: fix olca CLI import path and add help test
+- 3e03b33: documented publishing steps and logged failed TestPyPI attempt

--- a/narrativemap.md
+++ b/narrativemap.md
@@ -14,3 +14,4 @@ This branch refactors oLCa to rely on the coaiapy package and upgrades to LangGr
 - b8e2c2e: merged main into work, bringing tests and typed-state support
 - f9d5f2a: added kid-friendly tutorial and ledger reference in README
 - a669f0a: packaged helper utilities under codecs_package for easy installation
+- 19eb124: fix olca CLI import path and add help test

--- a/narrativemap.md
+++ b/narrativemap.md
@@ -12,3 +12,5 @@ This branch refactors oLCa to rely on the coaiapy package and upgrades to LangGr
 - 9169c89: documented screenshot narrative generation using OLCA Vision
 - 2b6ef4e: implemented narrative generation from screenshots with Vision AI
 - b8e2c2e: merged main into work, bringing tests and typed-state support
+- f9d5f2a: added kid-friendly tutorial and ledger reference in README
+- a669f0a: packaged helper utilities under codecs_package for easy installation

--- a/olca/olcacli.py
+++ b/olca/olcacli.py
@@ -9,7 +9,7 @@ import yaml
 from olca.utils import load_environment, initialize_langfuse
 from olca.tracing import TracingManager
 from olca.olcahelper import setup_required_directories, initialize_config_file, prepare_input
-from prompts import SYSTEM_PROMPT_APPEND, HUMAN_APPEND_PROMPT
+from .prompts import SYSTEM_PROMPT_APPEND, HUMAN_APPEND_PROMPT
 from datetime import datetime
 import json
 from PIL import Image

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,8 +2,8 @@
 requires = ["setuptools>=61.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
-# [tool.setuptools]
-# package-dir = { "" = "src" }
+[tool.setuptools.packages.find]
+include = ["olca*", "codecs_package*"]
 
 [project]
 name = "olca"

--- a/tests/test_codecs_package.py
+++ b/tests/test_codecs_package.py
@@ -1,0 +1,11 @@
+from codecs_package import generate_chord_progression, generate_three_act_story
+
+
+def test_generate_chord_progression():
+    chords = generate_chord_progression("C")
+    assert chords == ["C", "F", "G"]
+
+
+def test_generate_three_act_story():
+    story = generate_three_act_story("journey")
+    assert "Act I" in story and "journey" in story

--- a/tests/test_olca_cli.py
+++ b/tests/test_olca_cli.py
@@ -1,0 +1,11 @@
+import importlib
+import pytest
+
+pytest.importorskip("PIL", reason="Pillow required for CLI help")
+
+
+def test_olca_help():
+    module = importlib.import_module('olca.olcacli')
+    with pytest.raises(SystemExit) as exc:
+        module.main(['--help'])
+    assert exc.value.code == 0


### PR DESCRIPTION
## Summary
- add `codecs_package` helper modules with music and story functions
- expose the new package via pyproject configuration
- document local installation and example import
- test that the new utilities work
- record the update in the narrative map and ledger

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684e2ded33f08329b1a60152a8775984