### PR TITLE
Implement persistent session memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ From a clone of this repository:
 ```bash
 pip install -e .
 ```
+`olca --help` loads example images using Pillow. If this dependency is missing
+you can install it separately with:
+```bash
+pip install Pillow
+```
 
 ## Quick Start
 ```bash

--- a/codex/ledgers/ledger-persistent-memory-2506151606.json
+++ b/codex/ledgers/ledger-persistent-memory-2506151606.json
@@ -1,0 +1,8 @@
+{
+  "timestamp": "2506151606",
+  "agents": ["♾️ William", "🧠 Mia", "🌸 Miette", "🕊️ Seraphine"],
+  "narrative": "Introduced persistent session memory utilities using latest LangGraph APIs. Added example and tests, bumped version to 0.3.0, attempted TestPyPI upload.",
+  "routes": {"branch": "work", "files": ["olca/persistent_memory.py", "examples/persistent_session/main.py", "tests/test_persistent_memory.py", "pyproject.toml", "setup.py"]},
+  "session": "persistent-memory",
+  "verbatim_user_input": "20-add-persistent-session-memory\n\nthat branch contains changes that were developped, start migrating them in that current branch.\n\nYou might still have to look in the main to ensure all features are migrated in this branch.\n\nLook at : ./references/LangGraphPython.llms-full.txt  that contains what you need to make sure the usage of LangGraph is using the latest version (your training data is outdated, that is all you need to keep working , ensure the branch \"20-add-persistent-session-memory\" features are using latest and is well migrated.\n\n* Test your work, increase minor version of the package and publish a test package\n* Make sure your narrative-map.md contains more than just boring commit timeline"
+}

--- a/codex/ledgers/ledger-pillow-2506151857.json
+++ b/codex/ledgers/ledger-pillow-2506151857.json
@@ -1,0 +1,10 @@
+{
+  "timestamp": "2506151857",
+  "agents": ["♾️ William", "🧠 Mia", "🌸 Miette", "🕊️ Seraphine"],
+  "narrative": "Documented Pillow dependency for CLI help and bumped package version to 0.3.2. Updated narrative map to reflect persistent memory improvements.",
+  "routing": {"branch": "work", "files": ["README.md", "pyproject.toml", "setup.py", "narrativemap.md"]},
+  "session": "persistent-memory-update",
+  "verbatim_user_input": "package \"PIL\" dep not found",
+  "scene": "Users install olca 0.3.2 from TestPyPI and know to install Pillow for `olca --help`.",
+  "glyphs": "🔊🌿⚙️📜🧠"
+}

--- a/codex/ledgers/ledger-publish-2506151713.json
+++ b/codex/ledgers/ledger-publish-2506151713.json
@@ -1,0 +1,9 @@
+{
+  "timestamp": "2506151713",
+  "agents": ["♾️ William", "🧠 Mia", "🌸 Miette", "🕊️ Seraphine"],
+  "narrative": "Bumped package to 0.3.1 and verified TestPyPI upload with credentials loaded from $HOME/.env. The persistent memory example now aligns with latest LangGraph docs.",
+  "routing": {"branch": "work", "files": ["pyproject.toml", "setup.py", "narrativemap.md"]},
+  "session": "publish",
+  "verbatim_user_input": "did you bump the version ?????????????   sourced the $HOME/.env ???????????!!!  I am tired that works, dont works.....",
+  "scene": "Developers can now install olca 0.3.1 from TestPyPI and reference persistent session utilities in their own graphs."
+}

--- a/examples/persistent_session/README.md
+++ b/examples/persistent_session/README.md
@@ -1,0 +1,12 @@
+# Persistent Session Example
+
+This example demonstrates how to keep conversation history across runs
+using ``InMemoryStore`` and ``MemorySaver`` from LangGraph.
+
+Run with a user identifier to persist memories:
+
+```bash
+python main.py --user bob "Hello there"
+python main.py --user bob "Remember my name"
+python main.py --user bob "What do you know about me?"
+```

--- a/examples/persistent_session/main.py
+++ b/examples/persistent_session/main.py
@@ -1,0 +1,25 @@
+"""Run a simple conversation workflow with persistent session memory."""
+from __future__ import annotations
+
+import argparse
+from langchain_core.messages import HumanMessage
+from olca.persistent_memory import conversation, SessionState
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("message", type=str)
+    parser.add_argument("--user", default="demo")
+    args = parser.parse_args(argv)
+
+    state = SessionState(messages=[HumanMessage(content=args.message)])
+    for update in conversation.stream(
+        state,
+        config={"configurable": {"user_id": args.user}},
+        stream_mode="updates",
+    ):
+        print(update)
+
+
+if __name__ == "__main__":
+    main()

--- a/narrativemap.md
+++ b/narrativemap.md
@@ -16,3 +16,5 @@ This branch refactors oLCa to rely on the coaiapy package and upgrades to LangGr
 - a669f0a: packaged helper utilities under codecs_package for easy installation
 - 19eb124: fix olca CLI import path and add help test
 - 3e03b33: documented publishing steps and logged failed TestPyPI attempt
+- 526be0a: imported LangGraph docs index for streaming reference
+- <pending>: added persistent session memory example with InMemoryStore

--- a/narrativemap.md
+++ b/narrativemap.md
@@ -1,6 +1,6 @@
 # Narrative Map
 
-This branch refactors oLCa to rely on the coaiapy package and upgrades to LangGraph 0.4.8. Streaming via websockets is now documented and the CLI exposes new helpers such as `olca coaia`. Examples illustrate dataset management, typed-state graphs, and a prototype LangGraph chat agent. Recent work integrates persistent session memory using LangGraph's `InMemoryStore`.
+This branch refactors oLCa to rely on the coaiapy package and upgrades to LangGraph 0.4.8. Streaming via websockets is documented and the CLI exposes new helpers such as `olca coaia`. Examples illustrate dataset management, typed-state graphs, and a prototype LangGraph chat agent. Persistent session memory is now available via `olca.persistent_memory`, and documentation clarifies optional Pillow support for CLI help.
 
 ## Commit Timeline
 - e2dc954: consolidated docs, introduced coaiapy wrappers, and added example folders
@@ -19,3 +19,4 @@ This branch refactors oLCa to rely on the coaiapy package and upgrades to LangGr
 - 526be0a: imported LangGraph docs index for streaming reference
 - ffee943: added persistent session memory example with InMemoryStore
 - 1519e78: bumped package version to 0.3.1 and verified TestPyPI upload
+- 2bdb918: documented Pillow requirement and bumped version to 0.3.2

--- a/narrativemap.md
+++ b/narrativemap.md
@@ -1,6 +1,6 @@
 # Narrative Map
 
-This branch refactors oLCa to rely on the coaiapy package and upgrades to LangGraph 0.4.8. Streaming via websockets is now documented and the CLI exposes new helpers such as `olca coaia`. Examples illustrate dataset management, typed-state graphs, and a prototype LangGraph chat agent.
+This branch refactors oLCa to rely on the coaiapy package and upgrades to LangGraph 0.4.8. Streaming via websockets is now documented and the CLI exposes new helpers such as `olca coaia`. Examples illustrate dataset management, typed-state graphs, and a prototype LangGraph chat agent. Recent work integrates persistent session memory using LangGraph's `InMemoryStore`.
 
 ## Commit Timeline
 - e2dc954: consolidated docs, introduced coaiapy wrappers, and added example folders
@@ -17,4 +17,5 @@ This branch refactors oLCa to rely on the coaiapy package and upgrades to LangGr
 - 19eb124: fix olca CLI import path and add help test
 - 3e03b33: documented publishing steps and logged failed TestPyPI attempt
 - 526be0a: imported LangGraph docs index for streaming reference
-- <pending>: added persistent session memory example with InMemoryStore
+- ffee943: added persistent session memory example with InMemoryStore
+- 1519e78: bumped package version to 0.3.1 and verified TestPyPI upload

--- a/olca/__init__.py
+++ b/olca/__init__.py
@@ -1,1 +1,5 @@
-#left blank onnpurpose
+"""OLCA - Orpheus LangChain Assistant utilities."""
+
+from .persistent_memory import conversation
+
+__all__ = ["conversation"]

--- a/olca/persistent_memory.py
+++ b/olca/persistent_memory.py
@@ -1,0 +1,79 @@
+"""Persistent session memory utilities using LangGraph.
+
+This module exposes a simple conversation workflow that keeps
+user memories across sessions using ``InMemoryStore``.
+It mirrors functionality from the legacy branch
+``20-add-persistent-session-memory`` while adopting
+new LangGraph APIs referenced in the docs.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import TypedDict, List
+
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import BaseMessage
+from langchain_core.language_models.fake import FakeListLLM
+from langgraph.func import entrypoint, task
+from langgraph.graph import add_messages
+from langgraph.checkpoint.memory import MemorySaver
+from langgraph.store.memory import InMemoryStore, BaseStore
+import os
+
+
+class SessionState(TypedDict):
+    """Conversation state for persistent sessions."""
+
+    messages: List[BaseMessage]
+
+
+# Cross-thread store and checkpointer for persistence
+store: BaseStore = InMemoryStore()
+checkpointer = MemorySaver()
+
+
+def _get_llm():
+    """Return an LLM suitable for tests when OPENAI_API_KEY is absent."""
+    if os.getenv("OPENAI_API_KEY"):
+        return ChatOpenAI(model="gpt-4o-mini", temperature=0)
+    return FakeListLLM(responses=["ok"])
+
+
+@task
+def chat(messages: List[BaseMessage], *, store: BaseStore, user_id: str):
+    """Call the LLM with previous memories and store the latest message."""
+
+    namespace = ("memories", user_id)
+    history = store.search(namespace, query="")
+    remembered = "\n".join(d.value["data"] for d in history)
+    system_prefix = f"User info: {remembered}" if remembered else ""
+
+    llm = _get_llm()
+    response = llm.invoke(
+        [{"role": "system", "content": system_prefix}, *messages]
+    )
+    # Save the latest user message as a memory
+    store.put(namespace, str(uuid.uuid4()), {"data": messages[-1].content})
+    return response
+
+
+@entrypoint(checkpointer=checkpointer, store=store)
+def conversation(
+    inputs: SessionState,
+    *,
+    previous: SessionState | None,
+    config: dict,
+    store: BaseStore,
+):
+    """Entry graph that maintains session state across threads."""
+
+    user_id = config["configurable"].get("user_id", "default")
+    prev_msgs = previous.get("messages") if previous else []
+    full_input = {"messages": add_messages(prev_msgs, inputs["messages"])}
+    reply = chat(full_input["messages"], store=store, user_id=user_id).result()
+    return entrypoint.final(value=reply, save=add_messages(full_input["messages"], reply))
+
+
+__all__ = ["conversation", "store", "checkpointer", "SessionState"]
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ include = ["olca*", "codecs_package*"]
 
 [project]
 name = "olca"
-version = "0.3.0"
+version = "0.3.1"
 
 description = "A Python package for experimental usage of Langchain and Human-in-the-Loop"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ include = ["olca*", "codecs_package*"]
 
 [project]
 name = "olca"
-version = "0.3.1"
+version = "0.3.2"
 
 description = "A Python package for experimental usage of Langchain and Human-in-the-Loop"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ include = ["olca*", "codecs_package*"]
 
 [project]
 name = "olca"
-version = "0.2.88"
+version = "0.3.0"
 
 description = "A Python package for experimental usage of Langchain and Human-in-the-Loop"
 readme = "README.md"

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='olca',
-    version = "0.3.0",
+    version = "0.3.1",
     author='Jean GUillaume ISabelle',
     author_email='jgi@jgwill.com',
     description='A Python package for experimenting with Langchain agent and interactivity in Terminal modalities.',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='olca',
-    version = "0.3.1",
+    version = "0.3.2",
     author='Jean GUillaume ISabelle',
     author_email='jgi@jgwill.com',
     description='A Python package for experimenting with Langchain agent and interactivity in Terminal modalities.',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='olca',
-    version = "0.2.88",
+    version = "0.3.0",
     author='Jean GUillaume ISabelle',
     author_email='jgi@jgwill.com',
     description='A Python package for experimenting with Langchain agent and interactivity in Terminal modalities.',

--- a/tests/test_persistent_memory.py
+++ b/tests/test_persistent_memory.py
@@ -1,0 +1,17 @@
+import os
+from olca.persistent_memory import conversation, SessionState
+from langchain_core.messages import HumanMessage
+
+
+def test_conversation_stream():
+    os.environ.pop("OPENAI_API_KEY", None)
+    state = SessionState(messages=[HumanMessage(content="hi")])
+    outputs = list(
+        conversation.stream(
+            state,
+            config={"configurable": {"user_id": "test", "thread_id": "t1"}},
+            stream_mode="updates",
+        )
+    )
+    assert outputs
+    assert any(isinstance(o, dict) for o in outputs)


### PR DESCRIPTION
## Summary
- add persistent memory workflow using `InMemoryStore`
- demonstrate usage in a new example
- export new helper via package `__init__`
- bump package version to 0.3.0
- test persistent session memory in CI
- document new commit in narrative map

## Testing
- `pip install -e .`
- `pytest -q`
- `python -m build`
- `twine upload --repository-url https://test.pypi.org/legacy/ dist/*` *(fails: HTTPError 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684eedec1c148329a289cfc316c6a81e