### PR TITLE
Add Termux extras and Langfuse guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ Optional extras install tracing support:
 pip install 'olca[tracing]'
 ```
 
+From a cloned repository you can install the package in editable mode so all
+required modules are available:
+```bash
+pip install -e .
+```
+
 For Android devices using Termux, see [README.termux.md](README.termux.md) for
 additional setup notes.
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ required modules are available:
 pip install -e .
 ```
 
+This ensures dependencies like `python-dotenv` are available so the CLI can load
+environment variables.
+
 For Android devices using Termux, see [README.termux.md](README.termux.md) for
 additional setup notes.
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@ It appears in CLI output and documentation as a reminder of this evolving archit
 pip install olca
 ```
 
+Optional extras install tracing support:
+```bash
+pip install 'olca[tracing]'
+```
+
+For Android devices using Termux, see [README.termux.md](README.termux.md) for
+additional setup notes.
+
 ## Quick Start
 ```bash
 olca init            # create olca.yml in the current directory

--- a/README.termux.md
+++ b/README.termux.md
@@ -17,7 +17,11 @@ cd olca
 ./termux-install.sh
 ```
 
-The script installs dependencies using a minimal requirements file that avoids heavy gRPC packages. It then installs `olca` in editable mode.
+The script installs dependencies using a minimal requirements file that avoids heavy gRPC packages and then installs `olca` in editable mode. If you skip the script, run:
+```bash
+pip install -r requirements.txt && pip install -e .
+```
+to provide the necessary modules.
 
 ## Usage
 After installation you can run:

--- a/README.termux.md
+++ b/README.termux.md
@@ -1,0 +1,34 @@
+# Running oLCa on Termux
+
+This guide explains how to install and run the `olca` package on Android devices via [Termux](https://termux.dev).
+
+## Prerequisites
+- **Termux** from F‑Droid
+- `pkg install git python clang` for the base toolchain
+- Python 3.11 is recommended for best compatibility
+
+## Installation
+Clone the repository and use the helper script:
+
+```bash
+pkg install python git clang
+git clone https://github.com/jgwill/olca.git
+cd olca
+./termux-install.sh
+```
+
+The script installs dependencies using a minimal requirements file that avoids heavy gRPC packages. It then installs `olca` in editable mode.
+
+## Usage
+After installation you can run:
+
+```bash
+olca --help
+```
+
+Some optional tracing features require `langfuse`, which depends on `grpcio`. These are disabled by default on Termux. If you later need tracing, consider installing a prebuilt `grpcio` wheel manually.
+After installing `grpcio`, you can add tracing support with:
+```bash
+pip install 'olca[tracing]'
+```
+

--- a/README.termux.md
+++ b/README.termux.md
@@ -21,7 +21,8 @@ The script installs dependencies using a minimal requirements file that avoids h
 ```bash
 pip install -r requirements.txt && pip install -e .
 ```
-to provide the necessary modules.
+to provide the necessary modules, including `python-dotenv` for loading your
+environment variables.
 
 ## Usage
 After installation you can run:

--- a/codex/ledgers/ledger-termux-2506170243.json
+++ b/codex/ledgers/ledger-termux-2506170243.json
@@ -1,0 +1,12 @@
+{
+  "timestamp": "2506170243",
+  "agents": ["♾️ William", "🧠 Mia", "🌸 Miette", "🕊️ Seraphine"],
+  "narrative": "Introduced Termux support by removing langfuse and google generative AI from dependencies. Added conditional import logic for Langfuse, created a helper install script, and documented usage in README.termux.md.",
+  "routing": {
+    "files": ["README.md", "README.termux.md", "termux-install.sh", "pyproject.toml", "requirements.txt", "olca/utils.py"],
+    "branch": "work"
+  },
+  "session": "shell",
+  "verbatim_user_input": "File \"/data/data/com.termux/files/usr/tmp/pip-build-env-cm3jnjyh/overlay/lib/python3.12/site-packages/setuptools/_distutils/compilers/C/unix.py\", line 223, in _compile ... Failed building wheel for grpcio ...",
+  "scene": "oLCa can now be installed on Android devices via Termux without compiling grpcio."
+}

--- a/codex/ledgers/ledger-termux-2506170259.json
+++ b/codex/ledgers/ledger-termux-2506170259.json
@@ -1,0 +1,12 @@
+{
+  "timestamp": "2506170259",
+  "agents": ["♾️ William", "🧠 Mia", "🌸 Miette", "🕊️ Seraphine"],
+  "narrative": "Refined Termux support by guarding Langfuse imports and adding optional dependencies. README documents extras for tracing.",
+  "routing": {
+    "files": ["olca/tracing.py", "pyproject.toml", "README.md", "README.termux.md"],
+    "branch": "work"
+  },
+  "session": "shell",
+  "verbatim_user_input": "One of those branches contains some codes that are working very well, so I want you to look everywhere and build up what I need for my Termux phone.",
+  "scene": "Termux installs can enable tracing once grpcio wheels are installed, while running clean without langfuse."
+}

--- a/codex/ledgers/ledger-termux-2506170327.json
+++ b/codex/ledgers/ledger-termux-2506170327.json
@@ -1,0 +1,12 @@
+{
+  "timestamp": "2506170327",
+  "agents": ["♾️ William", "🧠 Mia", "🌸 Miette", "🕊️ Seraphine"],
+  "narrative": "Add dependency guards and clear install instructions for Termux users. README updates advise editable install and termux guide explains manual pip steps. olcacli now warns if langchain packages are missing.",
+  "routing": {
+    "files": ["olca/olcacli.py", "README.md", "README.termux.md"],
+    "branch": "work"
+  },
+  "session": "shell",
+  "verbatim_user_input": "python olcacli.py --help Traceback ModuleNotFoundError: No module named 'langchain_openai'",
+  "scene": "Running the CLI after cloning now prints a helpful message if dependencies weren't installed, guiding Termux setups." 
+}

--- a/codex/ledgers/ledger-termux-2506170347.json
+++ b/codex/ledgers/ledger-termux-2506170347.json
@@ -1,0 +1,12 @@
+{
+  "timestamp": "2506170347",
+  "agents": ["♾️ William", "🧠 Mia", "🌸 Miette", "🕊️ Seraphine"],
+  "narrative": "Added python-dotenv dependency and guarded imports so olca CLI runs without crashing on Termux. Documentation notes editable install provides dotenv.",
+  "routing": {
+    "files": ["pyproject.toml", "requirements.txt", "olca/olcacli.py", "olca/utils.py", "README.md", "README.termux.md", "termux-install.sh"],
+    "branch": "work"
+  },
+  "session": "shell",
+  "verbatim_user_input": "python olcacli.py init  Traceback (most recent call last): ModuleNotFoundError: No module named 'dotenv'",
+  "scene": "Fresh installations on Termux now include dotenv so environment variables load correctly."
+}

--- a/narrativemap.md
+++ b/narrativemap.md
@@ -12,3 +12,5 @@ This branch refactors oLCa to rely on the coaiapy package and upgrades to LangGr
 - 1240fa6: added Termux installation guide and stripped grpc dependencies
 - f9a4ee4: ledger documenting Termux support
 - 0259abcd: optional dependencies for tracing and graceful Langfuse import
+- 7a88c45: extras instructions and ledger for Termux support
+- 0a3cc5b: guarded CLI imports and clarified installation docs

--- a/narrativemap.md
+++ b/narrativemap.md
@@ -14,3 +14,4 @@ This branch refactors oLCa to rely on the coaiapy package and upgrades to LangGr
 - 0259abcd: optional dependencies for tracing and graceful Langfuse import
 - 7a88c45: extras instructions and ledger for Termux support
 - 0a3cc5b: guarded CLI imports and clarified installation docs
+- a889152: added dotenv dependency and guards for Termux CLI stability

--- a/narrativemap.md
+++ b/narrativemap.md
@@ -9,3 +9,6 @@ This branch refactors oLCa to rely on the coaiapy package and upgrades to LangGr
 - 7646734: added websocket streaming docs, CI workflow, and llms index
 - 1563243: websocket demo example and checkpointing notes
 - c182195: CI workflow refined and help tests added
+- 1240fa6: added Termux installation guide and stripped grpc dependencies
+- f9a4ee4: ledger documenting Termux support
+- 0259abcd: optional dependencies for tracing and graceful Langfuse import

--- a/olca/olcacli.py
+++ b/olca/olcacli.py
@@ -3,7 +3,10 @@ import os
 import sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 import dotenv
-from langchain import hub
+try:
+    from langchain import hub
+except ImportError as e:
+    raise SystemExit("Missing dependency 'langchain'. Install with 'pip install -r requirements.txt' or run ./termux-install.sh") from e
 import argparse
 import yaml
 from olca.utils import load_environment, initialize_langfuse
@@ -56,7 +59,10 @@ dotenv.load_dotenv()
 
 # First we initialize the model we want to use.
 from json import load
-from langchain_openai import ChatOpenAI,OpenAI
+try:
+    from langchain_openai import ChatOpenAI, OpenAI
+except ImportError as e:
+    raise SystemExit("Missing dependency 'langchain-openai'. Install with 'pip install -r requirements.txt' or run ./termux-install.sh") from e
 #from langchain.agents import AgentExecutor, create_react_agent
 
 from langchain_community.agent_toolkits.load_tools import load_tools

--- a/olca/olcacli.py
+++ b/olca/olcacli.py
@@ -2,7 +2,12 @@
 import os
 import sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-import dotenv
+try:
+    import dotenv
+except ImportError as e:
+    raise SystemExit(
+        "Missing dependency 'python-dotenv'. Install with 'pip install -r requirements.txt' or run ./termux-install.sh"
+    ) from e
 try:
     from langchain import hub
 except ImportError as e:

--- a/olca/tracing.py
+++ b/olca/tracing.py
@@ -33,13 +33,17 @@ class TracingManager:
             os.environ["LANGCHAIN_TRACING_V2"] = "true"
 
     def _setup_langfuse(self):
-        from langfuse.callback import CallbackHandler as LangfuseCallbackHandler
-        from langfuse import Langfuse
+        try:
+            from langfuse.callback import CallbackHandler as LangfuseCallbackHandler
+            from langfuse import Langfuse
+        except ImportError:
+            return None
+
         self.langfuse = initialize_langfuse()
         if not self.langfuse:
             print("Warning: Missing Langfuse environment variables")
             return None
-            
+
         return LangfuseCallbackHandler()
 
     def get_callbacks(self):

--- a/olca/utils.py
+++ b/olca/utils.py
@@ -1,15 +1,28 @@
 import os
 import sys
-import dotenv
+try:
+    import dotenv
+except ImportError:
+    dotenv = None
 import webbrowser
 
 def load_environment():
-    dotenv.load_dotenv(dotenv_path=os.path.join(os.getcwd(), ".env"))
+    if dotenv:
+        dotenv.load_dotenv(dotenv_path=os.path.join(os.getcwd(), ".env"))
     
     # Try loading from home directory if variables are still not set
-    if not all([os.getenv(key) for key in ["LANGFUSE_PUBLIC_KEY", "LANGFUSE_SECRET_KEY", "LANGFUSE_HOST", 
-                                          "LANGCHAIN_API_KEY", "OPENAI_API_KEY"]]):
-        dotenv.load_dotenv(dotenv_path=os.path.expanduser("~/.env"))
+    if not all([
+        os.getenv(key)
+        for key in [
+            "LANGFUSE_PUBLIC_KEY",
+            "LANGFUSE_SECRET_KEY",
+            "LANGFUSE_HOST",
+            "LANGCHAIN_API_KEY",
+            "OPENAI_API_KEY",
+        ]
+    ]):
+        if dotenv:
+            dotenv.load_dotenv(dotenv_path=os.path.expanduser("~/.env"))
 
 def initialize_langfuse(debug=False):
     try:

--- a/olca/utils.py
+++ b/olca/utils.py
@@ -11,8 +11,11 @@ def load_environment():
                                           "LANGCHAIN_API_KEY", "OPENAI_API_KEY"]]):
         dotenv.load_dotenv(dotenv_path=os.path.expanduser("~/.env"))
 
-def initialize_langfuse( debug=False):
-    from langfuse import Langfuse
+def initialize_langfuse(debug=False):
+    try:
+        from langfuse import Langfuse
+    except ImportError:
+        return None
     required_vars = ["LANGFUSE_PUBLIC_KEY", "LANGFUSE_SECRET_KEY", "LANGFUSE_HOST"]
     if not all(os.getenv(var) for var in required_vars):
         return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "langchain-experimental",
     "click",
     "langgraph>=0.4.8",
+    "python-dotenv",
     "pytz",
     "arxiv",
     "tlid",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,14 +31,16 @@ dependencies = [
     "langchain-experimental",
     "click",
     "langgraph>=0.4.8",
-    "langfuse",
     "pytz",
-    "google.generativeai",
     "arxiv",
     "tlid",
     "coaiapy",
     "websockets",
 ]
+
+[project.optional-dependencies]
+tracing = ["langfuse"]
+google = ["google.generativeai"]
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,9 +14,7 @@ langchain_ollama
 llm
 click
 langgraph>=0.4.8
-langfuse
 pytz
-google.generativeai
 arxiv
 tlid
 coaiapy

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ langchain_ollama
 llm
 click
 langgraph>=0.4.8
+python-dotenv
 pytz
 arxiv
 tlid

--- a/termux-install.sh
+++ b/termux-install.sh
@@ -1,0 +1,17 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# Simple helper to install olca on Termux
+
+set -e
+
+# Use python3.11 if available
+pkg install -y python git clang
+
+python3 -m pip install --upgrade pip
+
+# install dependencies without langfuse or google generative ai
+python3 -m pip install -r requirements.txt
+
+# install package in editable mode
+python3 -m pip install -e .
+
+echo "oLCa installed. Run 'olca --help' to get started."

--- a/termux-install.sh
+++ b/termux-install.sh
@@ -9,6 +9,7 @@ pkg install -y python git clang
 python3 -m pip install --upgrade pip
 
 # install dependencies without langfuse or google generative ai
+# includes python-dotenv for environment loading
 python3 -m pip install -r requirements.txt
 
 # install package in editable mode


### PR DESCRIPTION
## Summary
- make langfuse import optional in `tracing.py`
- provide optional dependencies for tracing extras
- document extras usage in README and Termux guide
- record ledger entry for improved Termux support

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6850d56faef48329bb2896f8b41e82e0